### PR TITLE
docs(readme): modernize Quickstart — add Docker, fix go get, troubleshooting (#9)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,23 +41,71 @@ Note: You will be running a pre-alpha version in testmode.
 Only Linux based OS are supported, please report any bug you find.
 if you can't see the demo please contact me.
 
-*****************************************************
-Setting a development environment and/or contributing
-*****************************************************
+************************************
+Setting up a development environment
+************************************
 
- Download, develop, compile and contribute! (requires a golang IDE, git and GO v1.19.4 or later)
+Quickstart — Docker (recommended)
+=================================
 
-- git clone https://github.com/dionyself/golang-cms.git
-- cd golang-cms
-- go get github.com/beego/bee/v2
-- go install github.com/beego/bee/v2
-- bee run
+The fastest way to run the demo locally. Requires only Docker.
 
-To run unittests, integration tests and Selenium Automation Testing.
+.. code-block:: bash
 
- - go test ./...
- - goconvey ./integration_tests
- - webdriver ./automated_tests
+   git clone https://github.com/dionyself/golang-cms.git
+   cd golang-cms
+   docker compose up --build
+
+Browse http://127.0.0.1:8080 and log in with ``user: test, password: test``.
+
+If you don't have ``docker compose`` (Compose v1), use ``docker-compose`` instead.
+
+Quickstart — local Go toolchain
+===============================
+
+Requires Go **1.21+** and a working C compiler (for the ``mattn/go-sqlite3`` cgo dependency).
+
+.. code-block:: bash
+
+   git clone https://github.com/dionyself/golang-cms.git
+   cd golang-cms
+   # Note: `go get` for installing executables is deprecated since Go 1.17.
+   # Use `go install` for the `bee` CLI.
+   go install github.com/beego/bee/v2@latest
+   export PATH="$PATH:$(go env GOPATH)/bin"
+   bee run
+
+Then open http://127.0.0.1:8080.
+
+If you prefer to manage dependencies through the standard toolchain, use:
+
+.. code-block:: bash
+
+   go mod download
+   go run .
+
+Troubleshooting
+===============
+
+* ``go get: command not found`` (Go 1.17+)
+   ``go get`` for installing executables was removed in Go 1.17. Use ``go install pkg@version`` instead.
+* ``cgo: C compiler not found`` when building ``go-sqlite3``
+   Install ``gcc`` (Linux: ``apt install build-essential`` / ``dnf install gcc`` ; macOS: ``xcode-select --install`` ; Windows: TDM-GCC or MinGW-w64).
+* Demo container exits immediately
+   Check ``docker logs <container_id>``; the most common cause is a port conflict on 8080.
+* ``bee: command not found`` after ``go install``
+   ``go install`` puts the binary in ``$(go env GOPATH)/bin``. Add that to your ``PATH`` (see the snippet above).
+
+****************
+Contributing
+****************
+
+* Fork the repository and create a feature branch.
+* Make sure ``go test ./...`` passes locally before opening a PR.
+* Run ``gofmt -s -w .`` and (optionally) ``golangci-lint run`` for style.
+* Open a pull request against the ``master`` branch.
+
+Integration tests live in ``integration_tests/`` and are run with the ``goconvey`` UI or ``go test``.
 
 .. |bitcoin| image:: https://raw.githubusercontent.com/dionyself/golang-cms/master/static/img/btttcc.png
    :height: 230px


### PR DESCRIPTION
## Summary

Closes #9 — modernizes the development environment section of README.rst.

## Issues with the current instructions

1. **`go get` is deprecated** for installing executables since Go 1.17. The current README tells users to run `go get github.com/beego/bee/v2` and then `go install` for the same package. This is misleading and fails on Go 1.21+.
2. **No Docker Compose quickstart.** The Demo section already uses `docker run`, but new contributors have to read the Dockerfile to see how to develop locally. A `docker compose up` snippet is the modern default.
3. **No troubleshooting section.** A first-time contributor hits at least three common errors: missing C compiler for `mattn/go-sqlite3` cgo, `bee: command not found`, and the `go get` deprecation. The issue body in #9 is itself an example of the first two.
4. **No Go version pin.** The README says "Go v1.19.4 or later", which is misleading — Go 1.21+ is required for the modern `go install` syntax to work without warnings.

## What's changed

**README.rst** — replaced the existing `Setting a development environment and/or contributing` section with:

1. **Quickstart — Docker (recommended).** `git clone`, `cd`, `docker compose up --build`, browse http://127.0.0.1:8080.
2. **Quickstart — local Go toolchain.** Updated to Go 1.21+, `go install ...@latest`, and a `PATH` snippet for the `bee` binary.
3. **Troubleshooting.** 4 common Q&As covering the deprecation, cgo, container exits, and missing `PATH`.
4. **Contributing section.** Separated from setup so it's discoverable on its own.

## What is NOT changed

- Title, badges, intro
- Features list
- Demo section (which already had a working `docker run` command)
- Donate image links at the bottom (out of scope for #9)

**Closes** #9